### PR TITLE
add const-constructed builder args

### DIFF
--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -106,9 +106,10 @@ impl LazyStaticType {
 
     pub fn get_or_init<T: PyClass>(&self, py: Python<'_>) -> *mut ffi::PyTypeObject {
         fn inner<T: PyClass>() -> *mut ffi::PyTypeObject {
+            use crate::pyclass::HasPyTypeBuilderArgs;
             // Safety: `py` is held by the caller of `get_or_init`.
             let py = unsafe { Python::assume_gil_acquired() };
-            create_type_object::<T>(py)
+            create_type_object(py, T::BUILDER_ARGS)
         }
 
         // Uses explicit GILOnceCell::get_or_init::<fn() -> *mut ffi::PyTypeObject> monomorphization


### PR DESCRIPTION
Adds a `const BUILDER_ARGS` which allows `create_type_object` to become concrete.
